### PR TITLE
Fix compilation with latest Theos (June 29 2026 patch)

### DIFF
--- a/Settings.x
+++ b/Settings.x
@@ -42,7 +42,8 @@ NSBundle *YTWKSBundle() {
 - (NSArray <NSNumber *> *)orderedCategories {
     if (self.type != 1 || class_getClassMethod(objc_getClass("YTSettingsGroupData"), @selector(tweaks)))
         return %orig;
-    NSMutableArray *mutableCategories = %orig.mutableCopy;
+    NSArray *categories = %orig;
+    NSMutableArray *mutableCategories = categories.mutableCopy;
     // Check if YTWKSSection already exists to avoid duplicates
     NSNumber *sectionNumber = @(YTWKSSection);
     if (![mutableCategories containsObject:sectionNumber]) {


### PR DESCRIPTION
Hey @fosterbarnes this fixes the compilation errors related to this recent Theos commit https://github.com/theos/theos/commit/3913415ce82614e66bdbcf0e2538288dd94f5011

This will patch the following error
```
Settings.x:45:21: error: incompatible pointer types initializing 'NSMutableArray *' with an expression of type 'NSArray<NSNumber *> *' [-Werror,-Wincompatible-pointer-types]
==> Compiling Settings.x (arm64)…
   45 |     NSMutableArray *mutableCategories = _logos_orig$_ungrouped$YTSettingsGroupData$orderedCategories(self, _cmd);
      |                     ^                   ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
1 error generated.
```

Credit for this patched version of the code was by PoomSmart